### PR TITLE
Removing vonmises.jl includes

### DIFF
--- a/src/problems_elasticity.jl
+++ b/src/problems_elasticity.jl
@@ -766,7 +766,6 @@ end
 #     Plastic material        #
 ###############################
 #=
-include("vonmises.jl")
 abstract PlaneStressLinearElasticPlasticProblem <: LinearElasticityProblem
 
 function PlaneStressLinearElasticPlasticProblem(name="plane stress linear elasticity", dim::Int=2, elements=[])

--- a/src/problems_elasticplastic.jl
+++ b/src/problems_elasticplastic.jl
@@ -1,8 +1,6 @@
 # This file is a part of JuliaFEM.
 # License is MIT: see https://github.com/JuliaFEM/JuliaFEM.jl/blob/master/LICENSE.md
 
-include("vonmises.jl")
-
 # Elasticity problems
 abstract ElasticPlasticProblem            <: AbstractProblem
 abstract PlaneStressElasticPlasticProblem <: ElasticPlasticProblem


### PR DESCRIPTION
Removing all vonmises.jl includes, since file is no longer
to be found in the repository. Vonmises.jl had definitions
for elasticplastic material models, but those definitions
have been moved to problems_elasticity.jl/problems_elasticplastic.jl
files.

fix #73