### PR TITLE
problems_mortar_3d.jl: rename function contains to approx_in

### DIFF
--- a/src/JuliaFEM.jl
+++ b/src/JuliaFEM.jl
@@ -8,7 +8,9 @@ This is JuliaFEM -- Finite Element Package
 """
 module JuliaFEM
 
-importall Base
+import Base: getindex, setindex!, convert, length, size, isapprox, similar,
+             start, first, next, done, last, endof, vec, ==, +, -, *, /, haskey, copy,
+             push!, isempty, empty!, append!, sparse, full, read
 
 using Logging
 

--- a/src/abaqus.jl
+++ b/src/abaqus.jl
@@ -1,7 +1,7 @@
 # This file is a part of JuliaFEM.
 # License is MIT: see https://github.com/JuliaFEM/JuliaFEM.jl/blob/master/LICENSE.md
 
-importall Base
+import Base: getindex, length
 
 using JuliaFEM
 using JuliaFEM.Preprocess

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -89,12 +89,12 @@ function length(f::DCTI)
     return 1
 end
 
-function Base.:*(c::Number, f::DCTI)
+function *(c::Number, f::DCTI)
     return c*f.data
 end
 
 """ Kind of spatial interpolation of DCTI. """
-function Base.:*(N::Matrix, f::DCTI)
+function *(N::Matrix, f::DCTI)
     @assert length(N) == 1
     return N[1]*f.data
 end
@@ -179,11 +179,11 @@ function start(field::DVTI)
     return 1
 end
 
-function Base.:+(f1::DVTI, f2::DVTI)
+function +(f1::DVTI, f2::DVTI)
     return DVTI(f1.data + f2.data)
 end
 
-function Base.:-(f1::DVTI, f2::DVTI)
+function -(f1::DVTI, f2::DVTI)
     return DVTI(f1.data - f2.data)
 end
 
@@ -192,20 +192,20 @@ function update!(field::DVTI, data::Union{Vector, Dict})
 end
 
 """ Take scalar product of DVTI and constant T. """
-function Base.:*(T::Number, field::DVTI)
+function *(T::Number, field::DVTI)
     return DVTI(T*field.data)
 end
 
 """ Take dot product of DVTI field and vector T. Vector length must match to the
 field length and this can be used mainly for interpolation purposes, i.e., u = ∑ Nᵢuᵢ.
 """
-function Base.:*(T::Vector, f::DVTI)
+function *(T::Vector, f::DVTI)
     @assert length(T) <= length(f)
     return sum([T[i]*f[i] for i=1:length(T)])
 end
 
 """ Take outer product of DVTI field and matrix T. """
-function Base.:*(T::Matrix, f::DVTI)
+function *(T::Matrix, f::DVTI)
     n, m = size(T)
     return sum([kron(T[:,i], f[i]') for i=1:m])'
 end

--- a/src/postprocess_utils.jl
+++ b/src/postprocess_utils.jl
@@ -1,8 +1,6 @@
 # This file is a part of JuliaFEM.
 # License is MIT: see https://github.com/JuliaFEM/JuliaFEM.jl/blob/master/LICENSE.md
 
-importall Base
-
 using JuliaFEM
 using DataFrames
 using HDF5

--- a/src/preprocess.jl
+++ b/src/preprocess.jl
@@ -12,7 +12,7 @@
 - etc only topology related stuff
 =#
 
-importall Base
+import Base: copy
 
 using JuliaFEM
 

--- a/src/preprocess_abaqus_reader.jl
+++ b/src/preprocess_abaqus_reader.jl
@@ -1,8 +1,6 @@
 # This file is a part of JuliaFEM.
 # License is MIT: see https://github.com/JuliaFEM/JuliaFEM.jl/blob/master/LICENSE.md
 
-importall Base
-
 element_has_nodes(::Type{Val{:C3D4}}) = 4
 element_has_type( ::Type{Val{:C3D4}}) = :Tet4
 


### PR DESCRIPTION
See issue #85. `contains` is now renamed to `approx_in`. I also
switched argument order, so this function is now called in a same
way function `in()`. Usage example:

    julia> P = Vector[[1.0, 1.0], [2.0, 2.0]]
    2-element Array{Array{T,1},1}:
     [1.0,1.0]
     [2.0,2.0]

    julia> q = [1.0, 1.0] + eps(Float64)
    2-element Array{Float64,1}:
     1.0
     1.0

    julia> in(q, P)
    false

    julia> approx_in(q, P)
    true

Also added docstring and usage example.