### PR TITLE
[bugfix] maximum dimension problem is miscalculated

### DIFF
--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -387,7 +387,7 @@ function initialize!(solver::Solver; show_info=true)
     end
     nnodes = length(nodes)
     info("Total number of nodes in problems: $nnodes")
-    maxdof = maximum(nnodes)*field_dim
+    maxdof = maximum(nodes)*field_dim
     info("# of max dof (=size of solution vector) is $maxdof")
     solver.u = zeros(maxdof)
     solver.la = zeros(maxdof)


### PR DESCRIPTION
Maximum dimension of problem was determined nnodes*dim while the correct way is max_node_id*dim. This was causing bugs when node ids is not starting from 1. I merge this myself right away if tests pass.