### PR TITLE
Fix return types for fields not defined

### DIFF
--- a/src/problems.jl
+++ b/src/problems.jl
@@ -295,7 +295,7 @@ function getindex(problem::Problem, field_name::AbstractString)
 end
 
 """ Return field calculated to nodal points for elements in problem p. """
-function (problem::Problem)(field_name::AbstractString, time::Float64=0.0)
+function (problem::Problem)(field_name::AbstractString, time::AbstractFloat=0.0)
     #if haskey(problem, field_name)
     #    return problem[field_name](time)
     #end

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -468,15 +468,30 @@ function get_all_elements(solver::Solver)
     return [elements...;]
 end
 
+"""
+Return nodal field from all problems defined in solver.
+
+Examples
+--------
+To return e.g. geometry defined in nodal points at time t=0.0, one can write:
+
+julia> solver("geometry", 0.0)
+"""
 function (solver::Solver)(field_name::String, time::Float64)
     fields = []
     for problem in get_problems(solver)
         field = problem(field_name, time)
+        if field == nothing
+            continue
+        end
         if length(field) == 0
             warn("no field $field_name found for problem $(problem.name)")
-        else
-            push!(fields, field)
+            continue
         end
+        push!(fields, field)
+    end
+    if length(fields) == 0
+        return Dict{Integer, Vector{Float64}}()
     end
     return merge(fields...)
 end

--- a/test/test_solvers_geometry_not_defined.jl
+++ b/test/test_solvers_geometry_not_defined.jl
@@ -1,0 +1,14 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/JuliaFEM.jl/blob/master/LICENSE.md
+
+using JuliaFEM
+using JuliaFEM.Testing
+
+@testset "get nodal field from boundary condition if geometry is not defined" begin
+    bc = Problem(Dirichlet, "bc without geometry", 3, "displacement")
+    bc.elements = [Element(Poi1, [1])]
+    @test bc("geometry", 0.0) == nothing
+    s = Solver(Linear, "test solver")
+    s.problems = [bc]
+    @test length(s("geometry", 0.0)) == 0
+end


### PR DESCRIPTION
See issue #117. Problem arises typically when boundary condition is created using
"nodal" elements of type ```Poi1```, but forget to define geometry and
```solvers("geometry", 0.0)``` fails in Xdmf update function. Fixed.