### PR TITLE
Add another loop to assembly procedure

### DIFF
--- a/src/assembly.jl
+++ b/src/assembly.jl
@@ -73,3 +73,11 @@ function assemble!(problem::Problem, time::Real, ::Type{Val{:mass_matrix}}; dens
     end
 end
 
+function assemble!(assembly::Assembly, problem::Problem, elements::Vector{Element}, time::Real)
+    warn("assemble!() this is default assemble operation, decreased performance can be expected without preallocation of memory!")
+    for element in elements
+        assemble!(assembly, problem, element, time)
+    end
+    return nothing
+end
+


### PR DESCRIPTION
Yet another loop, but this way we can preallocate matrices when
constructiong local matrices of elements with same dimensions (which is
the case in practice)