### PR TITLE
Implement new function create_nodal_elements

### DIFF
--- a/src/JuliaFEM.jl
+++ b/src/JuliaFEM.jl
@@ -138,7 +138,7 @@ export create_elements, Mesh, add_node!, add_nodes!, add_element!,
        create_node_set_from_element_set!, filter_by_element_set
 
 include("preprocess_abaqus_reader.jl")
-export abaqus_read_mesh, create_surface_elements
+export abaqus_read_mesh, create_surface_elements, create_nodal_elements
 
 include("preprocess_aster_reader.jl")
 export aster_read_mesh

--- a/src/preprocess_abaqus_reader.jl
+++ b/src/preprocess_abaqus_reader.jl
@@ -42,3 +42,19 @@ boundary conditions.
 function create_surface_elements(mesh::Mesh, surface_name::String)
     return create_surface_elements(mesh, Symbol(surface_name))
 end
+
+"""
+    create_nodal_elements(mesh::Mesh, node_set_name::String)
+
+Create a set of "nodal" elements from node set.
+
+Nodal elements are of type Poi1. In principle they don't have volume and it's
+not possible to integrate over them. It is however possible to add boundary
+conditions to them.
+"""
+function create_nodal_elements(mesh::Mesh, node_set_name::String)
+    node_ids = mesh.node_sets[Symbol(node_set_name)]
+    elements = [Element(Poi1, [j]) for j in node_ids]
+    update!(elements, "geometry", mesh.nodes)
+    return elements
+end

--- a/test/test_create_nodal_elements.jl
+++ b/test/test_create_nodal_elements.jl
@@ -1,0 +1,16 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/JuliaFEM.jl/blob/master/LICENSE.md
+
+using Base.Test
+
+using JuliaFEM
+using JuliaFEM.Preprocess
+
+@testset "test create nodal elements" begin
+    m = Mesh()
+    add_node!(m, 1, [0.0, 0.0])
+    add_node_to_node_set!(m, :test, 1)
+    els = create_nodal_elements(m, "test")
+    fel = first(els)
+    @test fel.connectivity == [1]
+end


### PR DESCRIPTION
This function can be used to create elements from node set defined
in mesh. Resulting elements are of type Poi1, that is, they don't
have any volume but it's still possible to add boundary conditions
to them which are then enforced in discrete sense.