### PR TITLE
Use global timer to measure performance

### DIFF
--- a/src/JuliaFEM.jl
+++ b/src/JuliaFEM.jl
@@ -9,12 +9,7 @@ This is JuliaFEM -- Finite Element Package
 module JuliaFEM
 
 using TimerOutputs
-const to = TimerOutput()
-function print_statistics()
-    println(to)
-end
-
-export print_statistics, @timeit, to
+export @timeit, print_timer
 
 import Base: getindex, setindex!, convert, length, size, isapprox, similar,
              start, first, next, done, last, endof, vec, ==, +, -, *, /, haskey, copy,

--- a/test/test_elasticity_2d_linear_with_surface_load.jl
+++ b/test/test_elasticity_2d_linear_with_surface_load.jl
@@ -49,5 +49,3 @@ using JuliaFEM
     u3_expected = f/E*[-nu, 1] + g/(2*E)*[-nu, 1]
     @test isapprox(u3, u3_expected)
 end
-
-print_statistics()


### PR DESCRIPTION
This makes syntax a little bit easier. Also, measure more accurately performance
of modal solver under investigation.