### PR TITLE
Add module Abaqus back to code

### DIFF
--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -4,3 +4,7 @@
 function assemble!(problem::Problem, time, ::Type{Val{:mass_matrix}})
     assemble_mass_matrix!(problem, time)
 end
+
+module Abaqus
+using JuliaFEM.Preprocess: create_surface_elements
+end


### PR DESCRIPTION
Abaqus module is added back to code into `deprecations.jl` to make
code in seminar paper run on 0.3.3.