### PR TITLE
Replace some rarely used functions

### DIFF
--- a/src/problems_contact_2d_autodiff.jl
+++ b/src/problems_contact_2d_autodiff.jl
@@ -123,7 +123,7 @@ function assemble!(problem::Problem{Contact}, time::Float64,
         for element in slave_elements
             conn = get_connectivity(element)
             push!(S, conn...)
-            gdofs = get_gdofs(element, field_dim)
+            gdofs = get_gdofs(problem, element)
             X_el = element("geometry", time)
             x_el = tuple( (X_el[i] + u[:,j] for (i,j) in enumerate(conn))... )
             #=
@@ -220,8 +220,8 @@ function assemble!(problem::Problem{Contact}, time::Float64,
                 l = 1/2*abs(xi1[2]-xi1[1])
                 isapprox(l, 0.0) && continue # no contribution in this master element
 
-                slave_dofs = get_gdofs(slave_element, field_dim)
-                master_dofs = get_gdofs(master_element, field_dim)
+                slave_dofs = get_gdofs(problem, slave_element)
+                master_dofs = get_gdofs(problem, master_element)
 
                 # 4. loop integration points of segment
                 for ip in get_integration_points(slave_element, 3)

--- a/src/problems_dirichlet.jl
+++ b/src/problems_dirichlet.jl
@@ -106,7 +106,7 @@ function assemble!(assembly::Assembly, problem::Problem{Dirichlet},
     nnodes = length(element)
     field_dim = get_unknown_field_dimension(problem)
     field_name = get_parent_field_name(problem)
-    gdofs = get_gdofs(element, field_dim)
+    gdofs = get_gdofs(problem, element)
     props = problem.properties
 
     if problem.properties.dual_basis

--- a/test/test_heat.jl
+++ b/test/test_heat.jl
@@ -87,7 +87,7 @@ end
     # Set constant flux g=6 on boundary. Accurate solution is
     # u(x,y) = x which equals T=1 on boundary.
     # at time t=1.0 all loads should be on.
-    empty!(problem)
+    empty!(problem.assembly)
     assemble!(problem, 1.0)
     A = full(problem.assembly.K)
     b = full(problem.assembly.f)


### PR DESCRIPTION
- `empty!(problem)` -> `empty!(problem.assembly)`
- `get_gdofs(element, ndim)` -> `get_gdofs(problem, element)`