### PR TITLE
improve performance in elasticity by moving out computation of X from integration point loop

### DIFF
--- a/src/problems_elasticity.jl
+++ b/src/problems_elasticity.jl
@@ -130,13 +130,14 @@ function assemble!(assembly::Assembly,
     for element in elements
 
         u = element("displacement", time)
+        X = element("geometry", time)
+
         fill!(Km, 0.0)
         fill!(Kg, 0.0)
         fill!(f_int, 0.0)
         fill!(f_ext, 0.0)
 
         for ip in get_integration_points(element)
-            X = element("geometry", time)
             eval_basis!(bi, X, ip)
             w = ip.weight*bi.detJ
             N = bi.N


### PR DESCRIPTION
Assembly loop:

Before:
```
 12.576967 seconds (37.65 M allocations: 1.852 GiB, 11.65% gc time)
```

After
```
 11.251927 seconds (35.27 M allocations: 1.692 GiB, 11.27% gc time)
```

2 million allocations less.
