### PR TITLE
change in old function name ucfirst to uppercasefirst, 

### DIFF
--- a/src/solvers_modal.jl
+++ b/src/solvers_modal.jl
@@ -289,7 +289,7 @@ function update_xdmf!(solver::Solver{Modal})
     # save modes
 
     temporal_collection = get_temporal_collection(xdmf)
-    unknown_field_name = ucfirst(get_unknown_field_name(solver))
+    unknown_field_name = uppercasefirst(get_unknown_field_name(solver))
     frames = []
 
     @timeit "save modes" for (j, eigval) in enumerate(real(solver.properties.eigvals))


### PR DESCRIPTION
which was preventing the beam examples from running