### PR TITLE
Give meaningful error message when assembling continuum elasticity problem fails

### DIFF
--- a/src/problems_elasticity.jl
+++ b/src/problems_elasticity.jl
@@ -394,6 +394,22 @@ function assemble!(assembly::Assembly,
     end
 end
 
+"""
+    assemble!(assembly, problem, elements, time, ::Type{Val{:continuum}})
+
+Assemble all other elements for continuum elasticity problems. Basically, throw
+an exception telling to filter invalid elements out from the element set.
+"""
+function assemble!(assembly::Assembly,
+                   problem::Problem{Elasticity},
+                   elements::Vector{Element{El}},
+                   time, ::Type{Val{:continuum}}) where El
+    @info("It looks that you are trying to assemble elements of type $El to 3d continuum "*
+          "problem. However, they are not supported yet. To filter out elements from a "*
+          "element set, try `filter(element->!isa(element, Element{$El}), elements)`")
+    error("Tried to assemble unsupported elements of type $El to 3d continuum problem.")
+end
+
 """ Return strain tensor. """
 function get_strain_tensor(problem, element, ip, time)
     gradu = element("displacement", ip, time, Val{:Grad})

--- a/test/test_problems_elasticity_assemble_3d_seg3.jl
+++ b/test/test_problems_elasticity_assemble_3d_seg3.jl
@@ -1,0 +1,12 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/JuliaFEM.jl/blob/master/LICENSE.md
+
+using JuliaFEM, Test
+
+# Test that if 3d continuum problem have some elements we don't know how to
+# deal with, raise error with clear message
+
+elements = [Element(Seg3, (1, 2, 3))]
+problem = Problem(Elasticity, "test seg3", 3)
+add_elements!(problem, elements)
+@test_throws ErrorException assemble!(problem, 0.0)


### PR DESCRIPTION
Sometimes user may have the wrong kind of elements in element set when
assembling 3d continuum problem. This could happen for example in
situations, where mesher is giving also segment elements. They may have
some use in certain situations, but currently we don't support them.
When assembly is failing for this reasons, we give a meaningful error
message:

[ Info: It looks that you are trying to assemble elements of type Seg3
to 3d continuum problem. However, they are not supported yet. To filter
out elements from a element set, try `filter(element->!isa(element,
Element{Seg3}), elements)`
ERROR: LoadError: Tried to assemble unsupported elements of type Seg3 to
3d continuum problem.

This commit closes issue #211.